### PR TITLE
add btrfs modules in initrd

### DIFF
--- a/07-initrd.sh
+++ b/07-initrd.sh
@@ -166,6 +166,27 @@ rm kernel-modules-*.txz
 }
 #install_fuse
 
+install_btrfs_progs() {
+echo "Downloading btrfs-progs..."
+rm -f btrfs-progs-*.txz
+LOC=`grep "\/btrfs-progs-.*-.*-.*\.txz$" slack.md5 | sed "s|\(.*\)  \./\(.*\)|\2|"`
+wget -q $SLACK2REPO/$LOC
+echo "Installing btrfs-progs..."
+spkg -qq --root=/boot/initrd-tree/ -i btrfs-progs-*.txz
+rm btrfs-progs-*.txz
+echo "Downloading kernel modules"
+MODULES=`grep "\/kernel-modules-.*-.*-.*\.txz$" slack.md5 | sed "s|\(.*\)  \./\(.*\)|\2|"`
+for LOC in $MODULES; do
+	wget -q $SLACK2REPO/$LOC
+done
+echo "Installing btrfs.ko kernel modules..."
+for i in `ls kernel-modules-*.txz`; do
+	tar xf $i -C /boot/initrd-tree --wildcards "*/btrfs.ko"
+done
+rm kernel-modules-*.txz
+}
+install_btrfs_progs
+
 install_httpfs2() {
 echo "Downloading httpfs2..."
 rm -f httpfs2-*.txz

--- a/10-efi.sh
+++ b/10-efi.sh
@@ -53,12 +53,16 @@ FTP="$CWD/ftp"
 
 # mount the slackware.org.uk ftp server with curlftpfs
 echo "Mounting ftp repository..."
-curlftpfs ftp://ftp.slackware.org.uk ftp
+#curlftpfs ftp://ftp.slackware.org.uk ftp
+#curlftpfs ftp://ftp.ntua.gr/pub/linux/ ftp
+curlftpfs ftp://ftp.osuosl.org/pub/slackware/slackware64-$ver ftp
 
 # get the slack EFI files
 echo "Getting the slackware EFI files..."
-cp -r $FTP/slackware/slackware64-$ver/EFI efi/
-cp $FTP/slackware/slackware64-$ver/isolinux/efiboot.img efi/
+#cp -r $FTP/slackware/slackware64-$ver/EFI ./
+#cp $FTP/slackware/slackware64-$ver/isolinux/efiboot.img isolinux/x86_64/
+cp -r $FTP/EFI ./
+cp $FTP/isolinux/efiboot.img isolinux/x86_64/
 
 # Slackware->Salix
 sed -i "s/Slackware/Salix/g" efi/EFI/BOOT/grub.cfg


### PR DESCRIPTION
btrfs-progs has to add in initrd so salix can installed on btrfs partitions. Even there is btrfs menu on installer installation failed because mkfs.btrfs and btrfs modules do not exist on initrd.
This has been tested on latest slackel.